### PR TITLE
Be able to print job id on scheduler.print_jobs.

### DIFF
--- a/apscheduler/job.py
+++ b/apscheduler/job.py
@@ -294,4 +294,4 @@ class Job(object):
         else:
             status = 'pending'
 
-        return u'%s (trigger: %s, %s)' % (self.name, self.trigger, status)
+        return u'%s (func: %s, trigger: %s, %s)' % (self.id, self.name, self.trigger, status)


### PR DESCRIPTION
This would be useful in the case we need to print jobs that have different ids, but use the same function.

```python
In [1]: from apscheduler.schedulers.background import BackgroundScheduler

In [2]: scheduler = BackgroundScheduler()

In [3]: def foo(arg=""):
   ...:     print arg
   ...:     

In [4]: scheduler.add_job(foo, 'interval', seconds=3, id="FOO", args=["foo"])
Out[4]: <Job (id=FOO name=foo)>

In [5]: scheduler.add_job(foo, 'interval', seconds=3, id="BAR", args=["bar"])
Out[5]: <Job (id=BAR name=foo)>

In [6]: scheduler.add_job(foo, 'interval', seconds=3)
Out[6]: <Job (id=83b06138a92c42709cd420780d225eda name=foo)>

In [7]: scheduler.print_jobs()
Pending jobs:
    foo (trigger: interval[0:00:03], pending)
    foo (trigger: interval[0:00:03], pending)
    foo (trigger: interval[0:00:03], pending)
```

This would print this instead, which in this case is more useful:

```python
In [7]: scheduler.print_jobs()
Pending jobs:
    FOO (func: foo, trigger: interval[0:00:03], pending)
    BAR (func: bar, trigger: interval[0:00:03], pending)
    83b06138a92c42709cd420780d225eda (func: foo, trigger: interval[0:00:03], pending)
```